### PR TITLE
Fix broken links when baseurl is provided

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,3 +1,3 @@
 {% for item in site.navigation_links %}
-  <a class="nav-menu-item{% if page.url == item.url %} active{% endif %}" href="{{ item.url }}">{{ item.title }}</a>
+  <a class="nav-menu-item{% if page.url == item.url %} active{% endif %}" href="{{ item.url | absolute_url}}">{{ item.title }}</a>
 {% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,7 +38,7 @@
     <div class="wrapper-masthead">
       <div class="container">
         <header class="masthead clearfix">
-          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" width="70" height="70" /></a>
+          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar | absolute_url }}" width="70" height="70" /></a>
 
           <div class="site-info">
             <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.title }}</a></h1>


### PR DESCRIPTION
When a developer sets a custom baseurl (so the location of the site is at https://<username>.github.io/<reponame>/), it breaks some links, because /<reponame> is not correctly inserted. This PR fixes those links, using the absolute_url filter.