### PR TITLE
Feature: enable image captions

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,0 +1,6 @@
+<figure>
+  <a href="{{ include.url }}" class="glightbox">
+    <img src="{{ include.url }}" alt="{{ include.alt || include.caption }}">
+  </a>
+  <figcaption>{{ include.caption }}</figcaption>
+</figure>

--- a/style.scss
+++ b/style.scss
@@ -126,8 +126,9 @@ figure > img {
 
 figcaption {
   font-size: 14px !important;
-  margin-top: -20px;
+  margin-top: 0;
   text-align: center;
+  color: $gray;
 }
 
 .gmnoprint img {


### PR DESCRIPTION
### Context
I'm using Forever Jekyll for my personal blog and I love it !

One thing I miss, though, is the ability to add captions to the images I use in my blog posts.
I went ahead and added it to my website.

I am sharing it here as it could be an interesting feature to add to this theme. 

### Goal
Add the ability to caption images.

### Work
I added a new `/_includes/image.html` file.
It is based on the documentation of the [figcation HTML tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption)

To add an image in a post, the follow call can be made:
```ruby
{% include image.html url="/assets/image/iceberg.jpg" alt="An iceberg in the sea" caption="Just the tip of the Iceberg..." %}
```
It accepts three variables:
* `url`: the path or URL to the image file
* `alt`: an alternate text for the image. If not specified, it falls back to the caption
* `caption`:  text content for the caption 

### Result
Here is what it looks like
<img width="904" alt="Screenshot 2022-12-06 at 16 50 05" src="https://user-images.githubusercontent.com/823279/205958886-7ac8b1fd-a42a-47dd-a6f4-eaac1bd2b4e9.png">

### Notes
The images loaded through this include file have automatically the Lightbox CSS class added. 
